### PR TITLE
(PUP-3844) Rename MSI to puppet-agent.msi

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,7 @@ The following MSI public properties are supported:
 
 To install silently on the command line:
 
-    msiexec /qn /l*v install.txt /i puppet.msi INSTALLDIR="C:\puppet" PUPPET_MASTER_SERVER="puppetmaster.lan"
+    msiexec /qn /l*v install.txt /i puppet-agent.msi INSTALLDIR="C:\puppet" PUPPET_MASTER_SERVER="puppetmaster.lan"
 
 Note that msiexec will execute asynchronously. If you want the install to execute synchronously on the command line, prepend `start /w` as follows:
 
@@ -174,13 +174,13 @@ Once the MSI packages have been built, they can be signed with the following tas
 
     Z:\vagrant\win\puppetwinbuilder\src\puppet_for_the_win>rake windows:sign
     signtool sign /d "Puppet Enterprise" /du "http://www.puppetlabs.com" /n "Puppet Labs" \
-      /t "http://timestamp.verisign.com/scripts/timstamp.dll" puppetenterprise.msi
+      /t "http://timestamp.verisign.com/scripts/timstamp.dll" puppet-agent.msi
     Done Adding Additional Store
-    Successfully signed and timestamped: puppetenterprise.msi
+    Successfully signed and timestamped: puppet-agent.msi
     signtool sign /d "Puppet" /du "http://www.puppetlabs.com" /n "Puppet Labs" \
-      /t "http://timestamp.verisign.com/scripts/timstamp.dll" puppet.msi
+      /t "http://timestamp.verisign.com/scripts/timstamp.dll" puppet-agent.msi
     Done Adding Additional Store
-    Successfully signed and timestamped: puppet.msi
+    Successfully signed and timestamped: puppet-agent.msi
 
 The command the Rake task is executing will require HTTP Internet access to timestamp.verisign.com in order to get a digitally signed timestamp.
 

--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -319,7 +319,7 @@ namespace :windows do
   task :msi => [:wixobj, :wixobj_ui, :version] do
     OBJS = FileList['wix/**/*.wixobj']
 
-    out = ENV['BRANDING'] =~ /enterprise/i ? 'puppetenterprise' : 'puppet'
+    out = 'puppet-agent'
     out = "#{out}-#{ENV['ARCH']}" if ENV['ARCH'] == 'x64'
     msi_file_name =  ENV['PKG_FILE_NAME'] || "#{out}.msi"
 
@@ -338,7 +338,7 @@ namespace :windows do
   # install the Windows SDK to get signtool.exe.  puppetwinbuilder.zip's
   # setup_env.bat should have added it to the PATH already.
   task :sign_pe => 'pkg' do |t|
-    msi_file_name =  ENV['PKG_FILE_NAME'] || 'puppetenterprise.msi'
+    msi_file_name =  ENV['PKG_FILE_NAME'] || 'puppet-agent.msi'
     Dir.chdir TOPDIR do
       Dir.chdir "pkg" do
         sh "signtool sign /d \"Puppet Enterprise\" /du \"http://www.puppetlabs.com\" /n \"Puppet Labs\" /t \"http://timestamp.verisign.com/scripts/timstamp.dll\" #{msi_file_name}"
@@ -351,7 +351,7 @@ namespace :windows do
   # install the Windows SDK to get signtool.exe.  puppetwinbuilder.zip's
   # setup_env.bat should have added it to the PATH already.
   task :sign_foss => 'pkg' do |t|
-    msi_file_name =  ENV['PKG_FILE_NAME'] || 'puppet.msi'
+    msi_file_name =  ENV['PKG_FILE_NAME'] || 'puppet-agent.msi'
     Dir.chdir TOPDIR do
       Dir.chdir "pkg" do
         sh "signtool sign /d \"Puppet\" /du \"http://www.puppetlabs.com\" /n \"Puppet Labs\" /t \"http://timestamp.verisign.com/scripts/timstamp.dll\" #{msi_file_name}"
@@ -365,14 +365,14 @@ namespace :windows do
 
   # This is also called from the build script in the Puppet Win Builder archive.
   # This will be called AFTER the update task in a new process.
-  desc "Build puppet.msi"
+  desc "Build puppet-agent.msi"
   task :build => :clean do |t|
     ENV['BRANDING'] = 'foss'
     ENV['PE_VERSION_STRING'] = nil
     Rake::Task["windows:msi"].invoke
   end
 
-  desc "Build puppetenterprise.msi"
+  desc "Build puppet-agent.msi"
   task :buildenterprise => :clean do |t|
     ENV['BRANDING'] = "enterprise"
     if not ENV['PE_VERSION_STRING']
@@ -397,7 +397,7 @@ namespace :windows do
 
   desc 'Install the MSI using msiexec'
   task :install => 'pkg' do |t|
-    msi_file_name =  ENV['PKG_FILE_NAME'] || 'puppet.msi'
+    msi_file_name =  ENV['PKG_FILE_NAME'] || 'puppet-agent.msi'
     Dir.chdir "pkg" do
       sh "msiexec /q /l*v install.txt /i #{msi_file_name} INSTALLDIR=\"C:\\puppet\" PUPPET_MASTER_SERVER=\"puppetmaster\" PUPPET_AGENT_CERTNAME=\"windows.vm\""
     end
@@ -405,7 +405,7 @@ namespace :windows do
 
   desc 'Uninstall the MSI using msiexec'
   task :uninstall => 'pkg' do |t|
-    msi_file_name =  ENV['PKG_FILE_NAME'] || 'puppet.msi'
+    msi_file_name =  ENV['PKG_FILE_NAME'] || 'puppet-agent.msi'
     Dir.chdir "pkg" do
       sh "msiexec /qn /l*v uninstall.txt /x #{msi_file_name}"
     end

--- a/test/test-installer.ps1
+++ b/test/test-installer.ps1
@@ -2,7 +2,7 @@ $hostname = [Net.Dns]::GetHostName()
 
 function Install-Puppet($opts)
 {
-  $params = @('/qn', '/i', 'pkg\puppet.msi', '/l*v', 'install.log')
+  $params = @('/qn', '/i', 'pkg\puppet-agent.msi', '/l*v', 'install.log')
   if ($opts.Account) { $params += "PUPPET_AGENT_ACCOUNT_USER=`"$($opts.Account)`"" }
   if ($opts.Domain) { $params += "PUPPET_AGENT_ACCOUNT_DOMAIN=`"$($opts.Domain)`"" }
   if ($opts.Password) { $params += "PUPPET_AGENT_ACCOUNT_PASSWORD=`"$($opts.Password)`"" }
@@ -73,7 +73,7 @@ function Install-Puppet($opts)
 function Uninstall-Puppet
 {
   Write-Host 'Uninstalling Puppet'
-  $uninst = @('/qn', '/x', 'pkg\puppet.msi')
+  $uninst = @('/qn', '/x', 'pkg\puppet-agent.msi')
   $process = Start-Process 'msiexec' -ArgumentList $uninst -Wait -PassThru
 
   if ($process.ExitCode -ne 0)

--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -15,7 +15,7 @@
   Name is made of localized product name and version number.
   -->
   <Product Id="$(var.ProductCode)" UpgradeCode="$(var.UpgradeCode)"
-    Name="$(var.OurProductName)$(var.OurProductPlatformText)"
+    Name="$(var.OurProductName) Agent$(var.OurProductPlatformText)"
     Language='1033'
     Codepage='1252'
     Version="$(var.ProductVersionNumber)"


### PR DESCRIPTION
Puppet.msi and PuppetEnterprise.msi are now named puppet-agent.msi.

Work for removing the branding branching logic is not included here so if anything looks weird, it will be cleaned up with [PUP-3843](https://tickets.puppetlabs.com/browse/PUP-3843). 

