### PR TITLE
(PUP-3842) Puppet should install MCO on FOSS

### DIFF
--- a/conf/windows/stage/bin/environment.bat.erb
+++ b/conf/windows/stage/bin/environment.bat.erb
@@ -19,24 +19,13 @@ SHIFT
 SET PUPPET_DIR=%PL_BASEDIR%\puppet
 SET FACTER_DIR=%PL_BASEDIR%\facter
 SET HIERA_DIR=%PL_BASEDIR%\hiera
-<%- if ENV["BRANDING"] == "enterprise" -%>
 SET MCOLLECTIVE_DIR=%PL_BASEDIR%\mcollective
 SET MCOLLECTIVE_PLUGIN_DIR=%PL_BASEDIR%\mcollective_plugins
-<% end -%>
 
-<%- if ENV["BRANDING"] == "enterprise" -%>
 SET PATH=%PUPPET_DIR%\bin;%FACTER_DIR%\bin;%HIERA_DIR%\bin;%MCOLLECTIVE_DIR%\bin;%PL_BASEDIR%\bin;%PL_BASEDIR%\sys\ruby\bin;%PL_BASEDIR%\sys\tools\bin;%PATH%
-<%- else -%>
-SET PATH=%PUPPET_DIR%\bin;%FACTER_DIR%\bin;%HIERA_DIR%\bin;%PL_BASEDIR%\bin;%PL_BASEDIR%\sys\ruby\bin;%PL_BASEDIR%\sys\tools\bin;%PATH%
-<%- end -%>
 
-<%- if ENV["BRANDING"] == "enterprise" -%>
 REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
 SET RUBYLIB=%PUPPET_DIR%\lib;%FACTER_DIR%\lib;%HIERA_DIR%\lib;%MCOLLECTIVE_DIR%\lib;%MCOLLECTIVE_PLUGIN_DIR%;%RUBYLIB%;
-<%- else -%>
-REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
-SET RUBYLIB=%PUPPET_DIR%\lib;%FACTER_DIR%\lib;%HIERA_DIR%\lib;%RUBYLIB%;
-<%- end -%>
 
 REM Translate all slashes to / style to avoid issue #11930
 SET RUBYLIB=%RUBYLIB:\=/%

--- a/foss-4.0-x64.yaml
+++ b/foss-4.0-x64.yaml
@@ -1,0 +1,17 @@
+---
+:repos:
+  puppet:
+    :ref: origin/master
+    :repo: git://github.com/puppetlabs/puppet.git
+  facter:
+    :ref: 2.3.0
+    :repo: git://github.com/puppetlabs/facter.git
+  hiera:
+    :ref: 1.3.4
+    :repo: git://github.com/puppetlabs/hiera.git
+  sys:
+    :ref: origin/2.0.0-x64
+    :repo: git://github.com/puppetlabs/puppet-win32-ruby.git
+  mcollective:
+    :ref: 2.7.0
+    :repo: git://github.com/puppetlabs/marionette-collective.git

--- a/foss-4.0-x86.yaml
+++ b/foss-4.0-x86.yaml
@@ -1,0 +1,17 @@
+---
+:repos:
+  puppet:
+    :ref: origin/master
+    :repo: git://github.com/puppetlabs/puppet.git
+  facter:
+    :ref: 2.3.0
+    :repo: git://github.com/puppetlabs/facter.git
+  hiera:
+    :ref: 1.3.4
+    :repo: git://github.com/puppetlabs/hiera.git
+  sys:
+    :ref: origin/1.9.3-x86
+    :repo: git://github.com/puppetlabs/puppet-win32-ruby.git
+  mcollective:
+    :ref: 2.7.0
+    :repo: git://github.com/puppetlabs/marionette-collective.git

--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -28,6 +28,7 @@ def variable_define_flags
   flags['PuppetDescTag'] = describe 'downloads/puppet'
   flags['FacterDescTag'] = describe 'downloads/facter'
   flags['HieraDescTag']  = describe 'downloads/hiera'
+  flags['MCODescTag']  = describe 'downloads/mcollective'
 
   # The regular expression with back reference groups for version string
   # parsing.  We re-use this against either git-describe on Puppet or on
@@ -47,7 +48,6 @@ def variable_define_flags
   when /enterprise/i
     flags['PackageBrand'] = "enterprise"
     msg = "Could not parse PE_VERSION_STRING env variable.  Set it with something like PE_VERSION_STRING=2.5.0"
-    flags['MCODescTag']  = describe 'downloads/mcollective'
     # The Package Version components for PE
     match_data = nil
     @version_regexps.find(lambda { raise ArgumentError, msg }) do |re|
@@ -238,10 +238,8 @@ namespace :windows do
   end
 
   task :wxs => [ :stage, 'wix/fragments' ] do
-    if ENV["BRANDING"] == "enterprise"
-      Rake::Task["windows:stage_plugins"].invoke
-      Rake::Task["windows:remove_vendor"].invoke
-    end
+    Rake::Task["windows:stage_plugins"].invoke
+    Rake::Task["windows:remove_vendor"].invoke
     FileList["stagedir/*"].each do |staging|
       name = File.basename(staging)
       heat("wix/fragments/#{name}.wxs", staging)

--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -226,8 +226,6 @@
                 <CreateFolder />
                 <File Id="PuppetDaemon" KeyPath="yes" Source="stagedir\service\daemon.rb" />
               </Component>
-              <!-- mcollective is only installed for Puppet Enterprise -->
-              <?if $(var.PackageBrand) = enterprise ?>
               <Component Id='MCOService' Guid="7601FCEA-90B3-CC69-6A69-4087FBC7292D" Win64="$(var.Win64)">
                 <File Id="MCODaemonBat" KeyPath="yes" Source="stagedir\service\mco_daemon.bat" />
                 <!-- This service is installed with start set to demand because
@@ -235,19 +233,19 @@
                 puppet run that configures mcollective will allow it to start
                 and set it to automatic -->
                 <ServiceInstall Id="MCOServiceInstaller"
-                  Account="LocalSystem"
+                  Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
+                  Password="[PUPPET_AGENT_ACCOUNT_PASSWORD]"
                   Description="Puppet Labs server orchestration framework"
                   DisplayName="Marionette Collective Server"
                   Interactive="no"
-                  Name="pe-mcollective"
+                  Name="mcollective"
                   Start="demand"
                   Type="ownProcess"
                   ErrorControl="normal"
                   Vital="yes"
                   />
-                <ServiceControl Id="MCOStartService" Stop="both" Remove="uninstall" Name="pe-mcollective" Wait="yes" />
+                <ServiceControl Id="MCOStartService" Stop="both" Remove="uninstall" Name="mcollective" Wait="yes" />
               </Component>
-              <?endif?>
             </Directory>
           </Directory>
         </Directory>
@@ -265,8 +263,6 @@
               </Component>
             </Directory>
           </Directory>
-          <!-- mcollective is only installed for Puppet Enterprise -->
-          <?if $(var.PackageBrand) = enterprise ?>
           <Directory Id="MCOAppData" Name="mcollective">
             <Directory Id="MCOConfDir" Name="etc">
               <Component Id="MCOConfDir" Permanent="yes" Guid="3E904914-17C7-138C-F5DF-280F680E067C">
@@ -281,7 +277,6 @@
               </Directory>
             </Directory>
           </Directory>
-          <?endif ?>
           <Directory Id="PuppetAppData" Name="puppet">
             <Directory Id="PuppetConfDir" Name="etc">
               <!-- This is a permanent directory, do not remove on uninstall -->
@@ -801,15 +796,11 @@
       <ComponentRef Id="PuppetServiceAutomatic" />
       <ComponentRef Id="PuppetServiceManual" />
       <ComponentRef Id="PuppetServiceDisabled" />
-
-      <!-- The MCO Parts are for Puppet Enterprise -->
-      <?if $(var.PackageBrand) = enterprise ?>
       <ComponentGroupRef Id="mcollective" />
       <ComponentGroupRef Id="mcollective_plugins" />
       <ComponentRef Id="MCOConfDir" />
       <ComponentRef Id="MCOLogDir" />
       <ComponentRef Id="MCOService" />
-      <?endif ?>
     </Feature>
   </Product>
 </Wix>


### PR DESCRIPTION
Add MCollective to be installed as part of the puppet agent
installer MSI. Previously MCO would only be installed if we were
building PuppetEnterprise.MSI. This removes the limitation and
additionally does the following:

- renames service from `pe-mcollective` to `mcollective`
- sets the intial account/password structure to the same as Puppet
which still defaults to `LocalSystem` and Empty password.