### PR TITLE
(PUP-3843) Remove branding

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,23 +31,11 @@ necessary tools, e.g. git, wix (heat, candle, and light), etc.
 
 Puppet For The Win composes an MSI from several different repositories. You will need to specify a configuration file to build it.
 
-## Open Source
+## Puppet Agent
 
-To build Puppet open source:
+To build Puppet agent:
 
-    C:\work\puppet_for_the_win>rake windows:build CONFIG=foss-stable.yaml
-
-## Puppet Enterprise
-
-To build Puppet Enterprise:
-
-    C:\work\puppet_for_the_win>rake windows:buildenterprise PE_VERSION_STRING=2.7.0 CONFIG=pe2.7.yaml
-
-Note that the `PE_VERSION_STRING` is needed to patch the puppet version source file.
-
-## Order Dependent Builds #
-
-The builds are order dependent. Build Puppet Enterprise after building Puppet FOSS, but not the other way around:
+    C:\work\puppet_for_the_win>rake windows:build AGENT_VERSION_STRING=1.0.0 CONFIG=foss-stable.yaml
 
 # User Facing Customizations #
 
@@ -173,10 +161,6 @@ Double clicking on the PFX file will install the certificate properly. I also re
 Once the MSI packages have been built, they can be signed with the following task:
 
     Z:\vagrant\win\puppetwinbuilder\src\puppet_for_the_win>rake windows:sign
-    signtool sign /d "Puppet Enterprise" /du "http://www.puppetlabs.com" /n "Puppet Labs" \
-      /t "http://timestamp.verisign.com/scripts/timstamp.dll" puppet-agent.msi
-    Done Adding Additional Store
-    Successfully signed and timestamped: puppet-agent.msi
     signtool sign /d "Puppet" /du "http://www.puppetlabs.com" /n "Puppet Labs" \
       /t "http://timestamp.verisign.com/scripts/timstamp.dll" puppet-agent.msi
     Done Adding Additional Store

--- a/wix/include/puppet.wxi
+++ b/wix/include/puppet.wxi
@@ -35,28 +35,15 @@
   <?define CommunityLink="http://links.puppetlabs.com/windows-installer-starting-out" ?>
   <?define ForgeLink="http://links.puppetlabs.com/forge-windows" ?>
 
-  <!-- Branding (foss|enterprise) -->
-  <?if $(var.PackageBrand) = enterprise ?>
-    <?define OurProductName="Puppet Enterprise" ?>
-    <?define OurProductNameWord="PuppetEnterprise" ?>
-    <?define NextStepLink="http://links.puppetlabs.com/windows-installer-next-steps-pe" ?>
-    <?define HelpLink="http://links.puppetlabs.com/customer-support-pe" ?>
-    <?define ManualLink="http://links.puppetlabs.com/windows-manual-pe" ?>
-    <?define VersionUIString="$(var.MajorVersion).$(var.MinorVersion).$(var.BuildVersion)" ?>
-    <?define BitmapFolder="wix\ui\bitmaps" ?>
-    <?define DialogBitmap="dlgbmp-pe.bmp" ?>
-    <?define PuppetServiceName="pe-puppet" ?>
-  <?else ?>
-    <?define OurProductName="Puppet" ?>
-    <?define OurProductNameWord="Puppet" ?>
-    <?define NextStepLink="http://links.puppetlabs.com/windows-installer-next-steps-foss" ?>
-    <?define HelpLink="http://links.puppetlabs.com/customer-support-foss" ?>
-    <?define ManualLink="http://links.puppetlabs.com/windows-manual-foss" ?>
-    <?define VersionUIString="$(var.PuppetDescTag)" ?>
-    <?define BitmapFolder="wix\ui\bitmaps" ?>
-    <?define DialogBitmap="dlgbmp-foss.bmp" ?>
-    <?define PuppetServiceName="puppet" ?>
-  <?endif ?>
+  <?define OurProductName="Puppet" ?>
+  <?define OurProductNameWord="Puppet" ?>
+  <?define NextStepLink="http://links.puppetlabs.com/windows-installer-next-steps-foss" ?>
+  <?define HelpLink="http://links.puppetlabs.com/customer-support-foss" ?>
+  <?define ManualLink="http://links.puppetlabs.com/windows-manual-foss" ?>
+  <?define VersionUIString="$(var.MajorVersion).$(var.MinorVersion).$(var.BuildVersion)" ?>
+  <?define BitmapFolder="wix\ui\bitmaps" ?>
+  <?define DialogBitmap="dlgbmp-foss.bmp" ?>
+  <?define PuppetServiceName="puppet" ?>
 
   <?if $(var.Platform) = x64 ?>
     <?define OurProductPlatformText=" (64-bit)" ?>

--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -297,27 +297,6 @@
                   Section="main"
                   Key="autoflush" Value="true"
                   Directory="PuppetConfDir" />
-                <!-- Only set these puppet.conf entries for Puppet Enterprise.
-                     This is to make Puppet FOSS consistent with Puppet FOSS on
-                     other platforms and Puppet Enterprise consistent with PE
-                     on other platforms. -->
-                <?if $(var.PackageBrand) = enterprise ?>
-                <IniFile Id="PuppetConfArchiveFiles" Name="puppet.conf"
-                  Action="createLine"
-                  Section="main"
-                  Key="archive_files" Value="true"
-                  Directory="PuppetConfDir" />
-                <IniFile Id="PuppetConfArchiveFileServer" Name="puppet.conf"
-                  Action="addLine"
-                  Section="main"
-                  Key="archive_file_server" Value="[PUPPET_MASTER_SERVER]"
-                  Directory="PuppetConfDir" />
-                <IniFile Id="PuppetConfGraph" Name="puppet.conf"
-                  Action="createLine"
-                  Section="main"
-                  Key="graph" Value="true"
-                  Directory="PuppetConfDir" />
-                <?endif ?>
               </Component>
               <Component Id="PuppetConfWithAgentEnvironment" Permanent="yes" Guid="EC56FB39-A176-42BA-BB1C-10C8DE76AE67">
                 <Condition>PUPPET_AGENT_ENVIRONMENT</Condition>


### PR DESCRIPTION
This removes PE specific branding. It does make the observation that
version is now preferred to the same way that PE formerly did it where
you pass in `PE_VERSION_STRING`. However that has been renamed to
`AGENT_VERSION_STRING` to more accurately reflect what it is used for.

This is still waiting on what happens with `puppet.conf` `graph`
setting in PE.

This depends on the work that went into https://github.com/puppetlabs/puppet_for_the_win/pull/83 and should be evaluated AFTER it.