### PR TITLE
(PUP-2638) create the $vardir/state/graphs folder

### DIFF
--- a/wix/localization/puppet_en-us.wxl
+++ b/wix/localization/puppet_en-us.wxl
@@ -256,8 +256,8 @@
 
     <String Id="WelcomeDlg_Title" Overridable="yes"><!-- _locID_text="WelcomeDlg_Title" _locComment="WelcomeDlg_Title" -->[ProductName] Setup</String>
     <String Id="WelcomeDlgBitmap" Overridable="yes"><!-- _locID_text="WelcomeDlgBitmap" _locComment="WelcomeDlgBitmap" -->WixUI_Bmp_Dialog</String>
-    <String Id="WelcomeDlgDescription" Overridable="yes"><!-- _locID_text="WelcomeDlgDescription" _locComment="WelcomeDlgDescription" -->This will install [ProductName] [VersionUIString] and configure the system to fetch configurations every half hour.&#13;&#10;&#13;&#10;This version of [ProductName] will work with puppet masters running Puppet 3.0 or higher.</String>
-    <String Id="WelcomeUpdateDlgDescriptionUpdate" Overridable="yes"><!-- _locID_text="WelcomeUpdateDlgDescriptionUpdate" _locComment="WelcomeUpdateDlgDescriptionUpdate" -->This will update [ProductName] to version [VersionUIString] and configure the system to fetch configurations every half hour.  This version of [ProductName] will work with puppet masters running Puppet 3.0 or higher.</String>
+    <String Id="WelcomeDlgDescription" Overridable="yes"><!-- _locID_text="WelcomeDlgDescription" _locComment="WelcomeDlgDescription" -->This will install [ProductName] [VersionUIString] and configure the system to fetch configurations every half hour.</String>
+    <String Id="WelcomeUpdateDlgDescriptionUpdate" Overridable="yes"><!-- _locID_text="WelcomeUpdateDlgDescriptionUpdate" _locComment="WelcomeUpdateDlgDescriptionUpdate" -->This will update [ProductName] to version [VersionUIString] and configure the system to fetch configurations every half hour.</String>
     <String Id="WelcomeDlgTitle" Overridable="yes"><!-- _locID_text="WelcomeDlgTitle" _locComment="WelcomeDlgTitle" -->{\WixUI_Font_Bigger}Welcome to the [ProductName] Setup Wizard</String>
 
     <String Id="WelcomeEulaDlg_Title" Overridable="yes"><!-- _locID_text="WelcomeEulaDlg_Title" _locComment="WelcomeEulaDlg_Title" -->[ProductName] Setup</String>

--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -359,9 +359,13 @@
                  puppet cannot create the directories it needs since the parent
                  does not exist. -->
             <Directory Id="PuppetVarDir" Name="var">
-              <Component Id="PuppetVarDir" Permanent="yes" Guid="B95A17F3-CF5E-4EC7-859E-F10C0965645F">
-                <CreateFolder />
-              </Component>
+              <Directory Id="PuppetStateDir" Name="state">
+                <Directory Id="PuppetGraphsDir" Name="graphs">
+                  <Component Id="PuppetVarDir" Permanent="yes" Guid="B95A17F3-CF5E-4EC7-859E-F10C0965645F">
+                    <CreateFolder />
+                  </Component>
+                </Directory>
+              </Directory>
             </Directory>
           </Directory>
           <Directory Id="HieraAppData" Name="hiera">

--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -102,7 +102,7 @@
             </Shortcut>
             <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
             <!-- This registry entry is required to be a keypath for this component -->
-            <RegistryValue Root="HKCU" Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurProductName)"
+            <RegistryValue Root="HKCU" Key="SOFTWARE\$(var.OurCompanyName)\$(var.OurProductNameWord)"
               Name="installed" Value="1" Type="integer" KeyPath="yes" />
           </Component>
           <Directory Id='PuppetShortcutDocumentationDir' Name="Documentation">


### PR DESCRIPTION
Running `puppet apply` before `puppet agent` with `graph` set to true
will cause the catalog application to fail because the required
directory is missing. Previously you would need to create
the directory manually or call `puppet agent -t` at least once, even if
to a non-existent master.

This also picks up at least one important maint commit - 

```
(maint) Remove Puppet Master compatibility message

This removes the notice of what version of puppet masters the product
will be compatible because it could be a Puppet Master, Puppet Server,
and those various versions. Honestly that information can be looked up
elsewhere, it doesn't provide much value in the installer.
```