### PR TITLE
(PUP-3845) Track versions of components

### DIFF
--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -220,7 +220,17 @@ namespace :windows do
     FileUtils.rm_rf(["stagedir/mcollective/lib/mcollective/vendor/json", "stagedir/mcollective/lib/mcollective/vendor/load_json.rb"])
   end
 
-  task :wxs => [ :stage, 'wix/fragments' ] do
+  task :track_versions do
+    version_tracking_file = 'stagedir/misc/versions.txt'
+    content = ""
+    FileList["downloads/*"].each do |repo|
+      content += "#{File.basename(repo)} #{describe repo}\n"
+    end
+
+    File.open(version_tracking_file, "wb") { |f| f.write(content) }
+  end
+
+  task :wxs => [ :stage, 'wix/fragments', :track_versions] do
     Rake::Task["windows:stage_plugins"].invoke
     Rake::Task["windows:remove_vendor"].invoke
     FileList["stagedir/*"].each do |staging|


### PR DESCRIPTION
Track versions of components in the MSI and install so that folks can
see exactly what went into the package. Create the file at
stagedir/misc just before heating the components so it gets baked into
the MSI and subsequently installed in
`INSTALLDIR/Puppet/misc/versions.txt`.