### PR TITLE
(maint) puppet agent updates

### DIFF
--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -134,7 +134,7 @@ namespace :windows do
               begin
                 sh "unzip #{config[:archive]} -d #{name}"
               rescue
-                sh "C:\\ProgramData\\chocolatey\\bin\\7za.exe x -r -tzip -o#{name} #{config[:archive]}"
+                sh "7za x -r -tzip -o#{name} #{config[:archive]}"
               end
               sh "rm #{config[:archive]}"
             end

--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -113,7 +113,7 @@ namespace :windows do
   CONFIG = YAML.load_file(ENV["config"] || "config.yaml")
   APPS = CONFIG[:repos]
   ENV['ARCH'] = ENV['ARCH'] || 'x86'
-  ENV['PKG_FILE_NAME'] = ENV['PKG_FILE_NAME'] || "puppet-agent-#{ENV['AGENT_VERSION_STRING']}-#{ENV['ARCH']}.msi"
+  ENV['PKG_FILE_NAME'] = (ENV['PKG_FILE_NAME'] || "puppet-agent-#{ENV['AGENT_VERSION_STRING']}-#{ENV['ARCH']}.msi").gsub(/\s+/, "")
 
   task :clean_downloads => 'downloads' do
     FileList["downloads/*"].each do |repo|
@@ -300,7 +300,7 @@ namespace :windows do
     if not ENV['AGENT_VERSION_STRING']
       puts "Warning: AGENT_VERSION_STRING is not set in the environment.  Defaulting to 1.0.0"
       ENV['AGENT_VERSION_STRING'] = '1.0.0'
-      ENV['PKG_FILE_NAME'] = "puppet-agent-#{ENV['AGENT_VERSION_STRING']}-#{ENV['ARCH']}.msi"
+      ENV['PKG_FILE_NAME'] = "puppet-agent-#{ENV['AGENT_VERSION_STRING']}-#{ENV['ARCH']}.msi".gsub(/\s+/, "")
     end
     Rake::Task["windows:msi"].invoke
   end

--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -131,7 +131,11 @@ namespace :windows do
           if config[:path]
             sh "curl -O #{config[:path]}/#{config[:archive]}"
             if config[:archive] =~ /^.*\.zip$/
-              sh "unzip #{config[:archive]} -d #{name}"
+              begin
+                sh "unzip #{config[:archive]} -d #{name}"
+              rescue
+                sh "C:\\ProgramData\\chocolatey\\bin\\7za.exe x -r -tzip -o#{name} #{config[:archive]}"
+              end
               sh "rm #{config[:archive]}"
             end
           else


### PR DESCRIPTION
This pull request adds in updates that are needed to build the puppet-agent msi on a vmpooler image. We are no longer using the puppetwinbuilder tarball to provide the necessary packages. Those are instead installed via chocolatey. Because of that, there are a few differences in how we invoke commands. 