### PR TITLE
(maint) Add the cfacter libdir to the ruby path

### DIFF
--- a/conf/windows/stage/bin/environment.bat
+++ b/conf/windows/stage/bin/environment.bat
@@ -25,7 +25,7 @@ SET MCOLLECTIVE_DIR=%PL_BASEDIR%\mcollective
 SET PATH=%PUPPET_DIR%\bin;%FACTER_DIR%\bin;%CFACTER_DIR%\bin;%HIERA_DIR%\bin;%MCOLLECTIVE_DIR%\bin;%PL_BASEDIR%\bin;%PL_BASEDIR%\sys\ruby\bin;%PL_BASEDIR%\sys\tools\bin;%PATH%
 
 REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
-SET RUBYLIB=%PUPPET_DIR%\lib;%FACTER_DIR%\lib;%HIERA_DIR%\lib;%MCOLLECTIVE_DIR%\lib;%RUBYLIB%;
+SET RUBYLIB=%PUPPET_DIR%\lib;%FACTER_DIR%\lib;%CFACTER_DIR%\lib;%HIERA_DIR%\lib;%MCOLLECTIVE_DIR%\lib;%RUBYLIB%;
 
 REM Translate all slashes to / style to avoid issue #11930
 SET RUBYLIB=%RUBYLIB:\=/%


### PR DESCRIPTION
We need to make sure this is available so that cfacter can load custom
facts, etc.