### PR TITLE
(maint) use git describe --long when tag is HEAD

### DIFF
--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -56,9 +56,16 @@ def variable_define_flags
   flags.inject([]) { |a, (k,v)| a << "-d#{k}=\"#{v}\"" }.join " "
 end
 
-def describe(dir)
+def describe(dir, style = :long)
   @git_tags ||= Hash.new
-  @git_tags[dir] ||= Dir.chdir(dir) { %x{git describe}.chomp }
+  @git_tags[dir] ||= Dir.chdir(dir) do
+    {
+      :long => %x{git describe --long}.chomp,
+      :short => %x{git describe}.chomp
+    }
+  end
+
+  @git_tags[dir][style]
 end
 
 def cp_p(src, dest, options={})
@@ -258,7 +265,7 @@ namespace :windows do
     msg = 'Could not parse git-describe annotated tag for MCollective'
     match_data=[]
     @version_regexps.find(lambda { raise ArgumentError, msg }) do |re|
-      match_data = (describe 'downloads/mcollective').match re
+      match_data = (describe 'downloads/mcollective', :short).match re
     end
     mco_version="#{match_data[1]}.#{match_data[2]}.#{match_data[3]}." << (match_data[4] || 0).to_s
     modified = content.gsub("@DEVELOPMENT_VERSION@", "#{mco_version}")

--- a/wix/include/puppet.wxi
+++ b/wix/include/puppet.wxi
@@ -4,8 +4,12 @@
   <?define OurCompanyNameWord="PuppetLabs"?>
   <?define OurCommonProductNameWord="PuppetInstaller"?>
 
-  <!-- Component Versions.  We expect the build system to define these values
-       on the command line using `git describe` -->
+  <!--
+  <![CDATA[
+  Component Versions.  We expect the build system to define these values
+         on the command line using `git describe ––long`
+  ]]>
+  -->
   <?ifndef PuppetDescTag ?><?define PuppetDescTag="X.Y.Z-123-abcdef1" ?><?endif ?>
   <?ifndef FacterDescTag ?><?define FacterDescTag="X.Y.Z-456-fedcba9" ?><?endif ?>
 


### PR DESCRIPTION
 - Git has some interesting behavior when using `git describe` when the
   current HEAD commit is a tag.  For instance, against the
   puppet-win32-ruby repository and git version 1.7.8.msysgit.0, the
   following behavior is observed, when performing a describe against
   93d40ef (which is tagged as 2.1.5.0-x86):

   > git describe
   > 2.1.5.0-x86
   > git describe --long
   > 2.1.5.0-x86-0-g93d40ef