### PR TITLE
(PUP-4006) Non-Git dependencies use VERSION file

### DIFF
--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -223,7 +223,9 @@ namespace :windows do
     version_tracking_file = 'stagedir/misc/versions.txt'
     content = ""
     FileList["downloads/*"].each do |repo|
-      content += "#{File.basename(repo)} #{describe repo}\n"
+      ver = Dir.exists?("#{repo}/.git") ?
+        describe(repo) : File.read("#{repo}/VERSION").strip
+      content += "#{File.basename(repo)} #{ver}\n"
     end
 
     File.open(version_tracking_file, "wb") { |f| f.write(content) }


### PR DESCRIPTION
 - Previously, for extracted zips, such as CFacter, the versions.txt
   included a `git describe --long` for the directory.  This would
   actually traverse to a parent directory until it found one, in this
   case the puppet_for_the_win repository itself.  As a result, the
   versions.txt would contain the version of the puppet_for_the_win
   repo, instead of the actual dependency.

   For CFacter, a VERSION file was added as part of:
   https://github.com/puppetlabs/cfacter/commit/26654b3

   When the current download directory has a .git folder, indicating a
   Git repo, then use `git describe --long` as we always have.

   Otherwise, read the contents of the `VERSION` file