### PR TITLE
(PUP-4006) Non-Git dependencies use VERSION file

### DIFF
--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -223,7 +223,22 @@ namespace :windows do
     version_tracking_file = 'stagedir/misc/versions.txt'
     content = ""
     FileList["downloads/*"].each do |repo|
-      content += "#{File.basename(repo)} #{describe repo}\n"
+      is_git = File.exists?("#{repo}/.git")
+      if is_git
+        version = describe(repo)
+      else
+        version_path = Dir["#{repo}/VERSION", "#{repo}/bin/VERSION"].first
+        if !version_path
+          abort "FAIL: #{repo} is not a Git repo, and is missing a VERSION file"
+        end
+
+        version = File.read(version_path).strip
+
+        if !version || version.empty?
+          abort "FAIL: #{repo} VERSION file missing version information"
+        end
+      end
+      content += "#{File.basename(repo)} #{version}\n"
     end
 
     File.open(version_tracking_file, "wb") { |f| f.write(content) }


### PR DESCRIPTION
 - Previously, for extracted zips, such as CFacter, the versions.txt
   included a `git describe --long` for the directory.  This would
   actually traverse to a parent directory until it found one, in this
   case the puppet_for_the_win repository itself.  As a result, the
   versions.txt would contain the version of the puppet_for_the_win
   repo, instead of the actual dependency.

   For CFacter, a VERSION file was added as part of:
   https://github.com/puppetlabs/cfacter/commit/26654b3

   When the current download directory has a .git folder, indicating a
   Git repo, then use `git describe --long` as we always have.

   Otherwise, read the contents of the `VERSION` file