### PR TITLE
(QENG-1892) Configure git clone with less memory

### DIFF
--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -146,7 +146,14 @@ namespace :windows do
               sh "rm #{config[:archive]}"
             end
           else
-            sh "git clone #{config[:repo]} #{name}"
+            FileUtils.mkdir(name)
+            Dir.chdir "#{TOPDIR}/downloads/#{name}" do
+              sh "git init"
+              sh "git remote add origin #{config[:repo]}"
+              sh "git config pack.windowMemory 10m"
+              sh "git config pack.packSizeLimit 20m"
+              sh "git fetch"
+            end
           end
         end
       end


### PR DESCRIPTION
 - Git clones of large repositories are failing in more resource
   constrained environments (such as the VMPooler instances that the
   new AIO pipeline is using).  This has resulted in errors like

```
     Resolving deltas:  46% (3744/8085)
     error: index-pack died of signal 11
     fatal: index-pack failed
     rake aborted!
```
   To address this issue, configure Git prior to cloning to adjust two
   key settings:

####   pack.windowMemory
   The maximum size of memory that is consumed by each thread in
   git-pack-objects[1] for pack window memory when no limit is given on
   the command line. The value can be suffixed with "k", "m", or "g".
   When left unconfigured (or set explicitly to 0), there will be no limit.

####   pack.packSizeLimit
   The maximum size of a pack. This setting only affects packing to a
   file when repacking, i.e. the git:// protocol is unaffected. It can
   be overridden by the --max-pack-size option of git-repack[1]. The
   minimum size allowed is limited to 1 MiB. The default is unlimited.
   Common unit suffixes of k, m, or g are supported.

   Some information discovered in SO thread:
   http://stackoverflow.com/questions/4826639/#4829883