### PR TITLE
(MCO-597) Ensure mco.bat

### DIFF
--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -178,6 +178,7 @@ namespace :windows do
 
     # Only copy the .bat files into place
     cp_p(FileList["conf/windows/stage/bin/*.bat"], "stagedir/bin/")
+    FileUtils.cp('downloads/mcollective/ext/windows/mco.bat', 'stagedir/bin/mco.bat') if File.exists?('downloads/mcollective/ext/windows/mco.bat')
   end
 
   task :misc => 'stagedir' do


### PR DESCRIPTION
Mco should be available as a command from the command line so ensure
that mco.bat is copied to the bin directory to be picked up as a
fragment.