### PR TITLE
(maint)(packaging) Cherry-pick fixes for mcollective 2.8 release to stable

### DIFF
--- a/conf/windows/stage/bin/environment.bat.erb
+++ b/conf/windows/stage/bin/environment.bat.erb
@@ -21,7 +21,6 @@ SET FACTER_DIR=%PL_BASEDIR%\facter
 SET HIERA_DIR=%PL_BASEDIR%\hiera
 <%- if ENV["BRANDING"] == "enterprise" -%>
 SET MCOLLECTIVE_DIR=%PL_BASEDIR%\mcollective
-SET MCOLLECTIVE_PLUGIN_DIR=%PL_BASEDIR%\mcollective_plugins
 <% end -%>
 
 <%- if ENV["BRANDING"] == "enterprise" -%>
@@ -32,7 +31,7 @@ SET PATH=%PUPPET_DIR%\bin;%FACTER_DIR%\bin;%HIERA_DIR%\bin;%PL_BASEDIR%\bin;%PL_
 
 <%- if ENV["BRANDING"] == "enterprise" -%>
 REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
-SET RUBYLIB=%PUPPET_DIR%\lib;%FACTER_DIR%\lib;%HIERA_DIR%\lib;%MCOLLECTIVE_DIR%\lib;%MCOLLECTIVE_PLUGIN_DIR%;%RUBYLIB%;
+SET RUBYLIB=%PUPPET_DIR%\lib;%FACTER_DIR%\lib;%HIERA_DIR%\lib;%MCOLLECTIVE_DIR%\lib;%RUBYLIB%;
 <%- else -%>
 REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
 SET RUBYLIB=%PUPPET_DIR%\lib;%FACTER_DIR%\lib;%HIERA_DIR%\lib;%RUBYLIB%;

--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -226,12 +226,6 @@ namespace :windows do
     FileUtils.cp('downloads/hiera/ext/hiera.yaml', 'stagedir/hiera/ext/hiera.yaml')
   end
 
-  task :stage_plugins => [ :stage ] do
-    puts "Moving MCO plugins into their own directory..."
-    FileUtils.mkdir_p "stagedir/mcollective_plugins"
-    FileUtils.mv("stagedir/mcollective/plugins/mcollective", "stagedir/mcollective_plugins/")
-  end
-
   task :remove_vendor => [ :stage ] do
     puts "Removing vendored JSON from mcollective..."
     FileUtils.rm_rf(["stagedir/mcollective/lib/mcollective/vendor/json", "stagedir/mcollective/lib/mcollective/vendor/load_json.rb"])
@@ -239,7 +233,6 @@ namespace :windows do
 
   task :wxs => [ :stage, 'wix/fragments' ] do
     if ENV["BRANDING"] == "enterprise"
-      Rake::Task["windows:stage_plugins"].invoke
       Rake::Task["windows:remove_vendor"].invoke
     end
     FileList["stagedir/*"].each do |staging|

--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -805,7 +805,6 @@
       <!-- The MCO Parts are for Puppet Enterprise -->
       <?if $(var.PackageBrand) = enterprise ?>
       <ComponentGroupRef Id="mcollective" />
-      <ComponentGroupRef Id="mcollective_plugins" />
       <ComponentRef Id="MCOConfDir" />
       <ComponentRef Id="MCOLogDir" />
       <ComponentRef Id="MCOService" />


### PR DESCRIPTION
This is a cherry-pick of 2 commits with fixes related to the Marionette Collective 2.8.x release to the stable branch. One related to moving the plugins into the lib dir, and the other updating the version handling for the Marionette Collective packaging