### PR TITLE
(MCO-625) Add mco.bat / required environment vars

### DIFF
--- a/conf/windows/stage/bin/mco.bat
+++ b/conf/windows/stage/bin/mco.bat
@@ -1,0 +1,6 @@
+@echo off
+SETLOCAL
+
+call "%~dp0environment.bat" %0 %*
+
+ruby -S -- "%SCRIPT_NAME%" %*

--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -178,7 +178,6 @@ namespace :windows do
 
     # Only copy the .bat files into place
     cp_p(FileList["conf/windows/stage/bin/*.bat"], "stagedir/bin/")
-    FileUtils.cp('downloads/mcollective/ext/windows/mco.bat', 'stagedir/bin/mco.bat')
   end
 
   task :misc => 'stagedir' do


### PR DESCRIPTION
Drop the use of the mco.bat from the marionette-collective repo
and instead prefer the use of an mco.bat included in PFW. This is
similar to how other bat files are included, e.g. puppet.bat and
facter.bat.

Also inlucde an environment variable for mcollectived.

This reverts changes introduced with https://github.com/puppetlabs/puppet_for_the_win/commit/07ea56edf9cbf96ffb920e35d9629d79cab339e5