### PR TITLE
(maint) Remove accidental Facter 'dir' fact

### DIFF
--- a/conf/windows/stage/bin/environment.bat
+++ b/conf/windows/stage/bin/environment.bat
@@ -17,15 +17,16 @@ REM Shift off the original command name we we were called
 SHIFT
 
 SET PUPPET_DIR=%PL_BASEDIR%\puppet
-SET FACTER_DIR=%PL_BASEDIR%\facter
+REM Facter will load FACTER_ env vars as facts, so don't use FACTER_DIR
+SET FACTERDIR=%PL_BASEDIR%\facter
 SET CFACTER_DIR=%PL_BASEDIR%\cfacter
 SET HIERA_DIR=%PL_BASEDIR%\hiera
 SET MCOLLECTIVE_DIR=%PL_BASEDIR%\mcollective
 
-SET PATH=%PUPPET_DIR%\bin;%FACTER_DIR%\bin;%CFACTER_DIR%\bin;%HIERA_DIR%\bin;%MCOLLECTIVE_DIR%\bin;%PL_BASEDIR%\bin;%PL_BASEDIR%\sys\ruby\bin;%PL_BASEDIR%\sys\tools\bin;%PATH%
+SET PATH=%PUPPET_DIR%\bin;%FACTERDIR%\bin;%CFACTER_DIR%\bin;%HIERA_DIR%\bin;%MCOLLECTIVE_DIR%\bin;%PL_BASEDIR%\bin;%PL_BASEDIR%\sys\ruby\bin;%PL_BASEDIR%\sys\tools\bin;%PATH%
 
 REM Set the RUBY LOAD_PATH using the RUBYLIB environment variable
-SET RUBYLIB=%PUPPET_DIR%\lib;%FACTER_DIR%\lib;%CFACTER_DIR%\lib;%HIERA_DIR%\lib;%MCOLLECTIVE_DIR%\lib;%RUBYLIB%;
+SET RUBYLIB=%PUPPET_DIR%\lib;%FACTERDIR%\lib;%CFACTER_DIR%\lib;%HIERA_DIR%\lib;%MCOLLECTIVE_DIR%\lib;%RUBYLIB%;
 
 REM Translate all slashes to / style to avoid issue #11930
 SET RUBYLIB=%RUBYLIB:\=/%


### PR DESCRIPTION
 - Facter will look for environment variables that begin with FACTER_
   and will automatically create facts out of them.  Inside of the
   environment.bat file called prior to the Puppet command line
   wrappers (puppet.bat, facter.bat, hiera.bat, etc) the temporary
   variable FACTER_DIR was used to set up the PATH.

   This had the interesting side effect of producing the DIR fact,
   which was totally unintended and unspecified.

   Simply rename this temp variable so that this doesn't happen.