### PR TITLE
(maint) Remove AppVeyor file from MSI

### DIFF
--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -213,7 +213,8 @@ namespace :windows do
                    %r{/Gemfile},
                    %r{/Rakefile},
                    %r{/README.md},
-                   %r{/*.patch}
+                   %r{/*.patch},
+                   %r{/appveyor.yml}
                  ]
       # This avoids copying hidden files like .gitignore and .git
       FileUtils.cp_r(FileList["#{app}/*"].exclude(*excludes), dst, :verbose => true)


### PR DESCRIPTION
Ensure that the appveyor.yml file doesn't get included with the
MSI.