### PR TITLE
(PUP-4631) Windows 2003 Deprecation Dialog

### DIFF
--- a/wix/PuppetForTheWin.wixproj
+++ b/wix/PuppetForTheWin.wixproj
@@ -32,6 +32,7 @@
     <Compile Include="ui\PuppetInstallDirDlg.wxs" />
     <Compile Include="ui\PuppetLicenseAgreementDlg.wxs" />
     <Compile Include="ui\PuppetWelcomeDlg.wxs" />
+    <Compile Include="ui\PuppetWarningDlg.wxs" />
     <Compile Include="ui\WixUI_PuppetInstallDir.wxs" />
   </ItemGroup>
   <ItemGroup>
@@ -56,6 +57,7 @@
     <Content Include="ui\PuppetInstallDirDlg.wixobj" />
     <Content Include="ui\PuppetLicenseAgreementDlg.wixobj" />
     <Content Include="ui\PuppetWelcomeDlg.wixobj" />
+    <Content Include="ui\PuppetWarningDlg.wixobj" />
     <Content Include="ui\WixUI_PuppetInstallDir.wixobj" />
   </ItemGroup>
   <ItemGroup>

--- a/wix/localization/puppet_en-us.wxl
+++ b/wix/localization/puppet_en-us.wxl
@@ -10,7 +10,7 @@
         which can be found in the file CPL.TXT at the root of this distribution.
         By using this software in any fashion, you are agreeing to be bound by
         the terms of this license.
-    
+
         You must not remove this notice, or any other, from this software.
     -->
 

--- a/wix/localization/puppet_en-us.wxl
+++ b/wix/localization/puppet_en-us.wxl
@@ -260,6 +260,11 @@
     <String Id="WelcomeUpdateDlgDescriptionUpdate" Overridable="yes"><!-- _locID_text="WelcomeUpdateDlgDescriptionUpdate" _locComment="WelcomeUpdateDlgDescriptionUpdate" -->This will update [ProductName] to version [VersionUIString] and configure the system to fetch configurations every half hour.</String>
     <String Id="WelcomeDlgTitle" Overridable="yes"><!-- _locID_text="WelcomeDlgTitle" _locComment="WelcomeDlgTitle" -->{\WixUI_Font_Bigger}Welcome to the [ProductName] Setup Wizard</String>
 
+    <String Id="WarningDlg_Title" Overridable="yes"><!-- _locID_text="WarningDlg_Title" _locComment="WarningDlg_Title" -->[ProductName] Setup</String>
+    <String Id="WarningDlgBitmap" Overridable="yes"><!-- _locID_text="WarningDlgBitmap" _locComment="WarningDlgBitmap" -->WixUI_Bmp_Dialog</String>
+    <String Id="WarningDlgDescription" Overridable="yes"><!-- _locID_text="WarningDlgDescription" _locComment="WarningDlgDescription" -->Microsoft end of support for Windows Server 2003 / 2003R2 is July 14, 2015. The next version of [ProductName] won't support Windows 2003 / 2003R2. &#xD;&#xA;&#xD;&#xA;http://links.puppetlabs.com/deprecate-windows-2003</String>
+    <String Id="WarningDlgTitle" Overridable="yes"><!-- _locID_text="WarningDlgTitle" _locComment="WarningDlgTitle" -->{\WixUI_Font_Bigger}Operating System Compatibility Warning</String>
+
     <String Id="WelcomeEulaDlg_Title" Overridable="yes"><!-- _locID_text="WelcomeEulaDlg_Title" _locComment="WelcomeEulaDlg_Title" -->[ProductName] Setup</String>
     <String Id="WelcomeEulaDlgBitmap" Overridable="yes"><!-- _locID_text="WelcomeEulaDlgBitmap" _locComment="WelcomeEulaDlgBitmap" -->WixUI_Bmp_Dialog</String>
     <String Id="WelcomeEulaDlgLicenseAcceptedCheckBox" Overridable="yes"><!-- _locID_text="WelcomeEulaDlgLicenseAcceptedCheckBox" _locComment="WelcomeEulaDlgLicenseAcceptedCheckBox" -->I &amp;accept the terms in the License Agreement</String>

--- a/wix/ui/PuppetWarningDlg.wxs
+++ b/wix/ui/PuppetWarningDlg.wxs
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) Microsoft Corporation.  All rights reserved.
+
+    The use and distribution terms for this software are covered by the
+    Common Public License 1.0 (http://opensource.org/licenses/cpl1.0.php)
+    which can be found in the file CPL.TXT at the root of this distribution.
+    By using this software in any fashion, you are agreeing to be bound by
+    the terms of this license.
+
+    You must not remove this notice, or any other, from this software.
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <UI>
+            <Dialog Id="PuppetWarningDlg" Width="370" Height="270" Title="!(loc.WarningDlg_Title)">
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" />
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)">
+                    <Publish Event="NewDialog" Value="PuppetWelcomeDlg" />
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+                    <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+                </Control>
+                <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" TabSkip="no" Text="!(loc.WarningDlgBitmap)" />
+                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+                <Control Id="Description" Type="Text" X="135" Y="80" Width="220" Height="60" Transparent="yes" NoPrefix="yes" Text="!(loc.WarningDlgDescription)" />
+                <Control Id="Title" Type="Text" X="135" Y="20" Width="220" Height="60" Transparent="yes" NoPrefix="yes" Text="!(loc.WarningDlgTitle)" />
+            </Dialog>
+        </UI>
+    </Fragment>
+</Wix>

--- a/wix/ui/PuppetWelcomeDlg.wxs
+++ b/wix/ui/PuppetWelcomeDlg.wxs
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) Microsoft Corporation.  All rights reserved.
-    
+
     The use and distribution terms for this software are covered by the
     Common Public License 1.0 (http://opensource.org/licenses/cpl1.0.php)
     which can be found in the file CPL.TXT at the root of this distribution.
     By using this software in any fashion, you are agreeing to be bound by
     the terms of this license.
-    
+
     You must not remove this notice, or any other, from this software.
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">

--- a/wix/ui/PuppetWelcomeDlg.wxs
+++ b/wix/ui/PuppetWelcomeDlg.wxs
@@ -21,7 +21,9 @@
                     <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
                 </Control>
                 <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" TabSkip="no" Text="!(loc.WelcomeDlgBitmap)" />
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="!(loc.WixUIBack)" />
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="!(loc.WixUIBack)">
+                    <Condition Action="hide">1</Condition>
+                </Control>
                 <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
                 <Control Id="Description" Type="Text" X="135" Y="80" Width="220" Height="60" Transparent="yes" NoPrefix="yes" Text="!(loc.WelcomeDlgDescription)" >
                     <Condition Action="show">NOT Installed OR NOT PATCH</Condition>

--- a/wix/ui/WixUI_PuppetInstallDir.wxs
+++ b/wix/ui/WixUI_PuppetInstallDir.wxs
@@ -14,6 +14,7 @@
 <!--
 First-time install dialog sequence:
  - WixUI_PuppetWelcomeDlg
+ - WixUI_PuppetWarningDlg (applicable to 2003)
  - WixUI_PuppetLicenseAgreementDlg
  - WixUI_PuppetInstallDirDlg
  - WixUI_VerifyReadyDlg
@@ -27,6 +28,7 @@ Maintenance dialog sequence:
 
 Patch dialog sequence:
  - WixUI_PuppetWelcomeDlg
+ - WixUI_PuppetWarningDlg (applicable to 2003)
  - WixUI_VerifyReadyDlg
 
 -->
@@ -59,11 +61,16 @@ Patch dialog sequence:
 
             <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 
-            <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg">NOT Installed</Publish>
-            <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
+            <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg"><![CDATA[VersionNT >= 600 AND NOT Installed]]></Publish>
+            <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg"><![CDATA[VersionNT >= 600 AND Installed AND PATCH]]></Publish>
+            <Publish Dialog="PuppetWelcomeDlg" Control="Next" Event="NewDialog" Value="PuppetWarningDlg"><![CDATA[VersionNT < 600]]></Publish>
 
-            <Publish Dialog="PuppetLicenseAgreementDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg">1</Publish>
+            <Publish Dialog="PuppetLicenseAgreementDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg"><![CDATA[VersionNT >= 600]]></Publish>
+            <Publish Dialog="PuppetLicenseAgreementDlg" Control="Back" Event="NewDialog" Value="PuppetWarningDlg"><![CDATA[VersionNT < 600]]></Publish>
             <Publish Dialog="PuppetLicenseAgreementDlg" Control="Next" Event="NewDialog" Value="PuppetInstallDirDlg">LicenseAccepted = "1"</Publish>
+
+            <Publish Dialog="PuppetWarningDlg" Control="Next" Event="NewDialog" Value="PuppetLicenseAgreementDlg">NOT Installed</Publish>
+            <Publish Dialog="PuppetWarningDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
 
             <Publish Dialog="PuppetInstallDirDlg" Control="Back" Event="NewDialog" Value="PuppetLicenseAgreementDlg">1</Publish>
             <Publish Dialog="PuppetInstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
@@ -75,7 +82,8 @@ Patch dialog sequence:
 
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="PuppetInstallDirDlg" Order="1">NOT Installed</Publish>
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
-            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg" Order="2">Installed AND PATCH</Publish>
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg" Order="2"><![CDATA[VersionNT >= 600 AND Installed AND PATCH]]></Publish>
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="PuppetWarningDlg" Order="2"><![CDATA[VersionNT < 600 AND Installed AND PATCH]]></Publish>
 
             <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
 

--- a/wix/ui/WixUI_PuppetInstallDir.wxs
+++ b/wix/ui/WixUI_PuppetInstallDir.wxs
@@ -2,13 +2,13 @@
 
 <!--
     Copyright (c) Microsoft Corporation.  All rights reserved.
-    
+
     The use and distribution terms for this software are covered by the
     Common Public License 1.0 (http://opensource.org/licenses/cpl1.0.php)
     which can be found in the file CPL.TXT at the root of this distribution.
     By using this software in any fashion, you are agreeing to be bound by
     the terms of this license.
-    
+
     You must not remove this notice, or any other, from this software.
 -->
 <!--
@@ -53,7 +53,7 @@ Patch dialog sequence:
             <DialogRef Id="ProgressDlg" />
             <DialogRef Id="ResumeDlg" />
             <DialogRef Id="UserExit" />
-            
+
             <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath" Order="3">1</Publish>
             <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
 
@@ -72,7 +72,7 @@ Patch dialog sequence:
             <Publish Dialog="PuppetInstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
             <Publish Dialog="PuppetInstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
             <Publish Dialog="PuppetInstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
-            
+
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="PuppetInstallDirDlg" Order="1">NOT Installed</Publish>
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="PuppetWelcomeDlg" Order="2">Installed AND PATCH</Publish>


### PR DESCRIPTION

 - Introduce a new dialog into the UI sequence that shows after the
   Welcome Dialog on Windows 2003 only.  It displays a link to more
   information on the upgrade path for Puppet from Windows 2003.
 - The dialog is dynamically injected into *only* the new install and
   patch UI sequences and not maintenance, based on the VersionNT
   property < 600.
 - We are able to use only the VersionNT (and not VersionNT64) property
   in this situation, because the installation is already blocked for
   the x64 installer on Windows 2003.
 - Note that there is nothing written to the installation log warning
   about 2003.  It appeared that a custom action was the only solution,
   and we're trying to avoid custom actions.
 - The previous attempt at providing this functionality in 32e1aeb,
   though simpler in code change terms, was actually deemed to be
   unsuitable.  The custom VBScript action had issues in a Cygwin
   environment, and after futher research, it was discovered that
   custom VBScript / JScript actions should never be used, because
   amongst other reasons, over-eager AV software may terminate the
   scripts altogether causing interesting failures.  For more
   information, see:

   http://blogs.msdn.com/b/robmen/archive/2004/05/20/136530.aspx