### PR TITLE
(RE-5011) Add a puppet-agent VERSION file to the Windows package

### DIFF
--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -229,6 +229,7 @@ namespace :windows do
 
   task :track_versions do
     version_tracking_file = 'stagedir/misc/versions.txt'
+    agent_version_file = 'stagedir/VERSION'
     content = ""
     FileList["downloads/*"].each do |repo|
       is_git = File.exists?("#{repo}/.git")
@@ -250,11 +251,12 @@ namespace :windows do
     end
 
     File.open(version_tracking_file, "wb") { |f| f.write(content) }
+    File.open(agent_version_file, "wb") { |f| f.write(ENV['AGENT_VERSION_STRING']) }
   end
 
   task :wxs => [ :stage, 'wix/fragments', :track_versions] do
     Rake::Task["windows:remove_vendor"].invoke
-    FileList["stagedir/*"].each do |staging|
+    Dir['stagedir/*'].select { |d| File.directory?(d) }.each do |staging|
       name = File.basename(staging)
       heat("wix/fragments/#{name}.wxs", staging)
     end

--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -142,6 +142,9 @@
       <Directory Id="$(var.PlatformProgramFilesFolder)" >
         <Directory Id='PuppetLabs' Name="$(var.OurCompanyName)">
           <Directory Id='INSTALLDIR' Name="$(var.OurProductName)">
+            <Component Id='PuppetAgentVersionFile' Guid="4A51050C-D761-472E-91D8-95FD2AB34384">
+              <File Id="VERSION" Source="stagedir\VERSION" KeyPath="yes" Checksum="yes"/>
+            </Component>
             <Directory Id='sys' Name='sys'>
               <Directory Id='ruby' Name ='ruby'>
                 <Directory Id='ruby_bin' Name='bin'>
@@ -801,6 +804,7 @@
       <ComponentRef Id="MCOConfDir" />
       <ComponentRef Id="MCOLogDir" />
       <ComponentRef Id="MCOService" />
+      <ComponentRef Id="PuppetAgentVersionFile" />
     </Feature>
   </Product>
 </Wix>


### PR DESCRIPTION
Currently, the Vanagon AIO package adds a VERSION file containing the
puppet-agent version string to the install directory.

This adds a corresponding file to the windows packages.