### PR TITLE
(RE-5539) Set SSL environment variables for windows processes

### DIFF
--- a/conf/windows/stage/bin/environment.bat
+++ b/conf/windows/stage/bin/environment.bat
@@ -33,3 +33,7 @@ SET RUBYLIB=%RUBYLIB:\=/%
 REM Enable rubygems support
 SET RUBYOPT=rubygems
 REM Now return to the caller.
+
+REM Set SSL variables to ensure trusted locations are used
+SET SSL_CERT_FILE=%WINDIR%\system32\ssl\cert.pem
+SET SSL_CERT_DIR=%WINDIR%\system32\ssl\certs


### PR DESCRIPTION
We want to ensure OpenSSL has secure settings, and the defaults are not
guarenteed to give us that. This commit updates SSL_CERT_FILE and
SSL_CERT_DIR to make sure we have safe locations set for both.