### PR TITLE
(RE-5539) Update SSL settings to secure default

### DIFF
--- a/conf/windows/stage/bin/environment.bat
+++ b/conf/windows/stage/bin/environment.bat
@@ -35,5 +35,5 @@ SET RUBYOPT=rubygems
 REM Now return to the caller.
 
 REM Set SSL variables to ensure trusted locations are used
-SET SSL_CERT_FILE=%WINDIR%\system32\ssl\cert.pem
-SET SSL_CERT_DIR=%WINDIR%\system32\ssl\certs
+SET SSL_CERT_FILE=%SystemRoot%\system32\ssl\cert.pem
+SET SSL_CERT_DIR=%SystemRoot%\system32\ssl\certs


### PR DESCRIPTION
Prior to this change, we were using %WINDIR% to define where our SSL
variables were set. This, however, is an insecure way of doing it.
%WINDIR% has three attack vectors associated with it, whereas
%SYSTEMROOT% only has one. The one attack vector for %SYSTEMROOT% is by
far more difficult to exploit. Because of this, we want to default  to
%SYSTEMROOT% rather than %WINDIR%. In a generic setup, %WINDIR% defaults
to %SYSTEMROOT%.

WinDir has three attack vectors:

  * Change the WinDir environment variable system wide.
  * Overload any environment variable over MAX_PATH (2048 chars I believe
  for env vars) and none of them (aside from built-in) work (PATH tends to
  hit this limit sometimes).
  * Change the WinDir environment variable in-process e.g. SET
  WinDir=C:\bad.

SystemRoot has this attack vector:

  * Change the SystemRoot environment variable in-process e.g. SET
  SystemRoot=C:\bad.