### PR TITLE
(PUP-5064) Block Windows Server 2003 Install

### DIFF
--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -55,10 +55,13 @@
 
     <?if $(var.Platform) = x64 ?>
       <!-- http://wixtoolset.org/documentation/manual/v3/howtos/redistributables_and_install_checks/block_install_on_os.html
-      http://windows-installer-xml-wix-toolset.687559.n2.nabble.com/How-to-add-newline-in-lt-Condition-message-td705721.html
         -->
-      <Condition Message="This 64-bit $(var.OurProductName) package does not support Windows Server 2003 because the 64-bit version of Ruby relies on OS features that Windows Server 2003 lacks.&#xD;&#xA;&#xD;&#xA;Please download and install the x86 version of the $(var.OurProductName) MSI instead.">
+      <Condition Message="$(var.OurProductName) is no longer supported on Windows Server 2003.">
         <![CDATA[Installed OR (VersionNT64 >= 600)]]>
+      </Condition>
+    <?else?>
+      <Condition Message="$(var.OurProductName) is no longer supported on Windows Server 2003.">
+        <![CDATA[Installed OR (VersionNT >= 600)]]>
       </Condition>
     <?endif ?>
 


### PR DESCRIPTION
Windows Server 2003 is no longer supported.

![windows2003](http://upboat.me/aa/I'm-not-saying-Windows-2003-has-to-go.../But-Windows-2003-has-to-go.jpg)