### PR TITLE
(PA-64) Set pxp-agent to exit on error

### DIFF
--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -275,7 +275,10 @@
                   <!-- Skip responding to WM_QUIT and WM_CLOSE -->
                   <RegistryValue Name="AppStopMethodSkip" Value="6" Type="integer" />
                   <RegistryKey Key="AppExit">
+                    <!-- Stop the service completely on exit(2) (Invalid configuration) otherwise restart with NSSM service throttling -->
+                    <!-- nssm AppExit codes reference https://nssm.cc/usage#exit -->
                     <RegistryValue Value="Restart" Type="string" />
+                    <RegistryValue Name="2" Value="Exit" Type="string" />
                   </RegistryKey>
                 </RegistryKey>
 


### PR DESCRIPTION
Change the behaviour from auto-restart to exit so that the pxp-agent service does not restart on error exit.