### PR TITLE
(PA-68) Filter test binaries from MSI

### DIFF
--- a/wix/filters/filters.xslt
+++ b/wix/filters/filters.xslt
@@ -14,4 +14,16 @@
   <!-- when the ruby.exe filter matches, do nothing -->
   <xsl:template match="wix:Component[wix:File[@Source='$(var.StageDir)\ruby\bin\ruby.exe']]" />
   <xsl:template match="wix:Component[wix:File[@Source='$(var.StageDir)\ruby\bin\rubyw.exe']]" />
+
+  <xsl:key name="tests-search" match="wix:Component[contains(wix:File/@Source, 'test')]" use="@Id" />
+  <xsl:template match="wix:Component[key('tests-search', @Id)]" />
+  <xsl:template match="wix:ComponentRef[key('tests-search', @Id)]" />
+
+  <xsl:key name="unittests-search" match="wix:Component[contains(wix:File/@Source, 'unittests.')]" use="@Id" />
+  <xsl:template match="wix:Component[key('unittests-search', @Id)]" />
+  <xsl:template match="wix:ComponentRef[key('unittests-search', @Id)]" />
+
+  <xsl:key name="lth_cat-search" match="wix:Component[contains(wix:File/@Source, 'lth_cat.exe')]" use="@Id" />
+  <xsl:template match="wix:Component[key('lth_cat-search', @Id)]" />
+  <xsl:template match="wix:ComponentRef[key('lth_cat-search', @Id)]" />
 </xsl:stylesheet>


### PR DESCRIPTION
Added WIX xslt filter that ignores test binaries when building the MSI.
While this could get verbose, we can eventually split the xslt files
among the different products (i.e. one for puppet, one for facter, etc)