### PR TITLE
(PA-68) Filter test assemblies for Puppet MSI

### DIFF
--- a/wix/filters/filters.xslt
+++ b/wix/filters/filters.xslt
@@ -14,4 +14,12 @@
   <!-- when the ruby.exe filter matches, do nothing -->
   <xsl:template match="wix:Component[wix:File[@Source='$(var.StageDir)\ruby\bin\ruby.exe']]" />
   <xsl:template match="wix:Component[wix:File[@Source='$(var.StageDir)\ruby\bin\rubyw.exe']]" />
+
+  <!-- Ignore test assemblies  -->
+  <xsl:template match="wix:Component[contains(wix:File/@Source, 'lth_cat.exe')]" />
+  <xsl:template match="wix:Component[contains(wix:File/@Source, 'libfacter_test.exe')]" />
+  <xsl:template match="wix:Component[contains(wix:File/@Source, 'libtest.so')]" />
+  <xsl:template match="wix:Component[contains(wix:File/@Source, 'libtest1.so')]" />
+  <xsl:template match="wix:Component[contains(wix:File/@Source, 'cpp-pcp-client-unittests.exe')]" />
+  <xsl:template match="wix:Component[contains(wix:File/@Source, 'pxp-agent-unittests.exe')]" />
 </xsl:stylesheet>


### PR DESCRIPTION
Use a WiX xslt filter to ignore the following files:

lth_cat.exe
libfacter_test.exe
libtest.so
libtest1.so
cpp-pcp-client-unittests.exe
pxp-agent-unittests.exe

The first attempt at this removed them from the staging directories
inside ther rake task for building the agent itself. This was decided to
be too heavy handed, as end users may want the test assemblies in
downstream CI pipelines.

The second attempt used WiX filters to ignore the specified files when generating
WiX fragment files from the staging directory. This was a better
approach in that it left the files for anyone who needed them, and
removed them on the packaging step where they were not wanted. However
the filters turned out to be too greedy, and removed hundreds of files
from the MSI.

The third attempt uses a stricter filter that only removes files
matching the names provided. There is too much overlap with words like
'test' to rely on simple matches. The better way to have approached this
is to have an xslt for each product (one for puppet, one for facter,
etc...) however this would require changing the rake tasks significantly
and would probably be superseded by vanagaon.