### PR TITLE
(PUP-5933) Don't set pluginsync in puppet.conf

### DIFF
--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -325,11 +325,6 @@
                   Section="main"
                   Key="server" Value="[PUPPET_MASTER_SERVER]"
                   Directory="PuppetConfDir" />
-                <IniFile Id="PuppetConfPluginSync" Name="puppet.conf"
-                  Action="createLine"
-                  Section="main"
-                  Key="pluginsync" Value="true"
-                  Directory="PuppetConfDir" />
                 <IniFile Id="PuppetConfAutoflush" Name="puppet.conf"
                   Action="createLine"
                   Section="main"


### PR DESCRIPTION
As of Puppet 4.4.0, setting the pluginsync option by CLI
or config is deprecated and will log a deprecation warning,
as that behavior will eventually be managed based on whether or not
we are using a cached catalog.

While the setting is deprecated, it still defaults to true,
so removing this setting in puppet.conf will not cause a
change in behavior.