### PR TITLE
(PA-225) Remove pluginsync setting from conf

### DIFF
--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -325,6 +325,11 @@
                   Section="main"
                   Key="server" Value="[PUPPET_MASTER_SERVER]"
                   Directory="PuppetConfDir" />
+                <IniFile Id="RemovePuppetConfPluginSync" Name="puppet.conf"
+                    Action="removeLine"
+                    Section="main"
+                    Key="pluginsync"
+                    Directory="PuppetConfDir" />
                 <IniFile Id="PuppetConfAutoflush" Name="puppet.conf"
                   Action="createLine"
                   Section="main"


### PR DESCRIPTION
During upgrade scenarios, if the pluginsync value is found,
it should be removed from the puppet.conf file. This is follow up
for a7f45d46e018038b26dfd653465b6f581d27e1fe, which deprecated
setting the pluginsync value.