### PR TITLE
(WIP)(PA-285) Brand Name Change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
    Puppet For The Win - Generating Puppet on Windows packages.
 
-   Copyright (C) 2005-2013 Puppet Labs Inc
+   Copyright (C) 2005-2016 Puppet, Inc.
 
-   Puppet Labs can be contacted at: info@puppetlabs.com
+   Puppet Inc can be contacted at: info@puppet.com
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ This project requires these tools from the `puppetwinbuilder` Dev Kit for Window
 # Getting Started #
 
 Download the [Puppet Win
-Builder](http://links.puppetlabs.com/puppetwinbuilder) archive, and unzip into `C:/puppetwinbuilder/`. Once extracted, execute the
+Builder](https://downloads.puppet.com/development/puppetwinbuilder.zip) archive, and unzip into `C:/puppetwinbuilder/`. Once extracted, execute the
 `setup_env.bat` script which will update your PATH to include the
 necessary tools, e.g. git, wix (heat, candle, and light), etc.
 
@@ -151,7 +151,7 @@ Here's the less scary notification when installing a signed package:
 ![User Account Control](http://dl.dropbox.com/u/17169007/img/Screen%20Shot%202012-03-14%20at%203.40.15%20PM.png)
 
 To digitally sign the packages, the [Puppet Labs Code Signing
-Certificate](https://groups.google.com/a/puppetlabs.com/group/tech/browse_thread/thread/3d85b1da489af092#)
+Certificate](https://groups.google.com/a/puppet.com/group/tech/browse_thread/thread/3d85b1da489af092#)
 should be installed into the user store on the windows build host.  If Jenkins is being used to automate the package builds, then this certificate and private key should be installed using the same account the Jenkins agent is running as.
 
 There should only be one code signing certificate installed.  The `signtool` will automatically select the right certificate if there is only one of them installed.
@@ -161,7 +161,7 @@ Double clicking on the PFX file will install the certificate properly. I also re
 Once the MSI packages have been built, they can be signed with the following task:
 
     Z:\vagrant\win\puppetwinbuilder\src\puppet_for_the_win>rake windows:sign
-    signtool sign /d "Puppet" /du "http://www.puppetlabs.com" /n "Puppet Labs" \
+    signtool sign /d "Puppet" /du "http://www.puppet.com" /n "Puppet Labs" \
       /t "http://timestamp.verisign.com/scripts/timstamp.dll" puppet-agent.msi
     Done Adding Additional Store
     Successfully signed and timestamped: puppet-agent.msi

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 
 # This rakefile is meant to be run from within the [Puppet Win
-# Builder](http://links.puppetlabs.com/puppetwinbuilder) tree.
+# Builder](https://downloads.puppetlabs.com/development/puppetwinbuilder.zip) tree.
 
 # Ensure '.' is in the LOAD_PATH in Ruby 1.9.2
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__))

--- a/tasks/windows/windows.rake
+++ b/tasks/windows/windows.rake
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 
 # This rakefile is meant to be run from within the [Puppet Win
-# Builder](http://links.puppetlabs.com/puppetwinbuilder) tree.
+# Builder](https://downloads.puppetlabs.com/development/puppetwinbuilder.zip) tree.
 
 # Load Rake
 begin
@@ -298,7 +298,7 @@ namespace :windows do
   task :sign => 'pkg' do |t|
     Dir.chdir TOPDIR do
       Dir.chdir "pkg" do
-        sh "signtool sign /d \"Puppet\" /du \"http://www.puppetlabs.com\" /n \"Puppet Labs\" /t \"http://timestamp.verisign.com/scripts/timstamp.dll\" #{ENV['PKG_FILE_NAME']}"
+        sh "signtool sign /d \"Puppet\" /du \"http://www.puppet.com\" /n \"Puppet Inc\" /t \"http://timestamp.verisign.com/scripts/timstamp.dll\" #{ENV['PKG_FILE_NAME']}"
       end
     end
   end

--- a/wix/include/puppet.wxi
+++ b/wix/include/puppet.wxi
@@ -34,14 +34,14 @@
        IF IT CHANGES. REALLY!  DON'T DO IT! -->
   <?define UpgradeCode="2AD3D11C-61B3-4710-B106-B4FDEC5FA358" ?>
 
-  <?define CommunityLink="http://links.puppetlabs.com/windows-installer-starting-out" ?>
-  <?define ForgeLink="http://links.puppetlabs.com/forge-windows" ?>
+  <?define CommunityLink="http://docs.puppet.com/community" ?>
+  <?define ForgeLink="http://forge.puppet.com" ?>
 
   <?define OurProductName="Puppet" ?>
   <?define OurProductNameWord="Puppet" ?>
-  <?define NextStepLink="http://links.puppetlabs.com/windows-installer-next-steps-foss" ?>
-  <?define HelpLink="http://links.puppetlabs.com/customer-support-foss" ?>
-  <?define ManualLink="http://links.puppetlabs.com/windows-manual-foss" ?>
+  <?define NextStepLink="http://docs.puppet.com/pe/latest/quick_start_install_agents_windows.html" ?>
+  <?define HelpLink="http://puppet.com/services/customer-support" ?>
+  <?define ManualLink="http://docs.puppet.com/puppet/latest/reference" ?>
   <?define VersionUIString="$(var.MajorVersion).$(var.MinorVersion).$(var.BuildVersion)" ?>
   <?define BitmapFolder="wix\ui\bitmaps" ?>
   <?define DialogBitmap="dlgbmp-foss.bmp" ?>

--- a/wix/localization/puppet_en-us.wxl
+++ b/wix/localization/puppet_en-us.wxl
@@ -89,7 +89,7 @@
     <String Id="FatalError_Title" Overridable="yes"><!-- _locID_text="FatalError_Title" _locComment="FatalError_Title" -->[ProductName] Setup</String>
     <String Id="FatalErrorBitmap" Overridable="yes"><!-- _locID_text="FatalErrorBitmap" _locComment="FatalErrorBitmap" -->WixUI_Bmp_Dialog</String>
     <String Id="FatalErrorTitle" Overridable="yes"><!-- _locID_text="FatalErrorTitle" _locComment="FatalErrorTitle" -->{\WixUI_Font_Bigger}[ProductName] Setup Wizard ended prematurely</String>
-    <String Id="FatalErrorDescription1" Overridable="yes"><!-- _locID_text="FatalErrorDescription1" _locComment="FatalErrorDescription1" -->The [ProductName] installer has encountered an error from which it cannot recover.  Please visit our windows installer support page: http://links.puppetlabs.com/windows_installer_error</String>
+    <String Id="FatalErrorDescription1" Overridable="yes"><!-- _locID_text="FatalErrorDescription1" _locComment="FatalErrorDescription1" -->The [ProductName] installer has encountered an error from which it cannot recover.  Please visit our windows installer support page: https://docs.puppet.com/puppet/latest/reference/install_windows.html</String>
     <String Id="FatalErrorDescription2" Overridable="yes"><!-- _locID_text="FatalErrorDescription2" _locComment="FatalErrorDescription2" -->Click the Finish button to exit the Setup Wizard.</String>
 
     <String Id="FeaturesDlg_Title" Overridable="yes"><!-- _locID_text="FeaturesDlg_Title" _locComment="FeaturesDlg_Title" -->[ProductName] Setup</String>

--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -25,7 +25,7 @@
       InstallerVersion='300'
       InstallScope="perMachine"
       Description="$(var.OurProductName)$(var.OurProductPlatformText) Installer"
-      Comments="http://www.puppetlabs.com/"
+      Comments="http://www.puppet.com/"
       Compressed="yes"
       Platform="$(var.Platform)"
       />


### PR DESCRIPTION
As part of the brand rename, 'puppetlabs.com' has become 'puppet.com'.
This PR changes all instances to the correct name.

Still todo:

- [x] http://links.puppetlabs.com/puppetwinbuilder
- [x] http://links.puppetlabs.com/windows-installer-starting-out
- [x] http://links.puppetlabs.com/windows-installer-next-steps-foss
- [x] http://links.puppetlabs.com/customer-support-foss
- [x] http://links.puppetlabs.com/windows-manual-foss