### PR TITLE
(PA-286) remove default environment setting in puppet.conf

### DIFF
--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -708,10 +708,6 @@ End If
       Property="PUPPET_AGENT_ENVIRONMENT"
       Value="[CMDLINE_PUPPET_AGENT_ENVIRONMENT]"
       Execute="firstSequence" />
-    <CustomAction Id="SetDefaultPuppetAgentEnvironment"
-      Property="PUPPET_AGENT_ENVIRONMENT"
-      Value="production"
-      Execute="firstSequence" />
     <!-- PUPPET_AGENT_CERTNAME -->
     <CustomAction Id="SetFromIniPuppetAgentCertname"
       Property="PUPPET_AGENT_CERTNAME"
@@ -816,9 +812,6 @@ End If
       <Custom Action='SetFromCmdLinePuppetAgentEnvironment' After='FileCost'>
         CMDLINE_PUPPET_AGENT_ENVIRONMENT
       </Custom>
-      <Custom Action='SetDefaultPuppetAgentEnvironment' Before='CostFinalize'>
-        PUPPET_AGENT_ENVIRONMENT=""
-      </Custom>
       <!-- PUPPET_AGENT_CERTNAME -->
       <Custom Action='SetFromIniPuppetAgentCertname' Before='FileCost'>
         INI_PUPPET_AGENT_CERTNAME
@@ -873,9 +866,6 @@ End If
       <Custom Action='SaveCmdLinePuppetAgentEnvironment' Before='AppSearch' />
       <Custom Action='SetFromCmdLinePuppetAgentEnvironment' After='FileCost'>
         CMDLINE_PUPPET_AGENT_ENVIRONMENT
-      </Custom>
-      <Custom Action='SetDefaultPuppetAgentEnvironment' Before='CostFinalize'>
-        PUPPET_AGENT_ENVIRONMENT=""
       </Custom>
        <!-- PUPPET_AGENT_CERTNAME -->
       <Custom Action='SetFromIniPuppetAgentCertname' Before='FileCost'>


### PR DESCRIPTION
In the current windows puppet setup, when installing the agent, the MSI will
update the puppet.conf file with environment=production by default. this will
break the workflow described in
https://docs.puppet.com/pe/latest/console_classes_groups_environment_override.html#workflow
so we need to update the MSI so it sets no default value.